### PR TITLE
fix: run stacks in response to click events

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -497,9 +497,11 @@ class Blocks {
                 this.emitProjectChanged();
             }
             break;
-        case 'stackClick':
+        case 'click':
             // UI event: clicked scripts toggle in the runtime.
-            this.runtime.toggleScript(e.blockId, {stackClick: true});
+            if (e.targetType === 'block') {
+                this.runtime.toggleScript(this.getTopLevelScript(e.blockId), {stackClick: true});
+            }
             break;
         }
     }

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -308,12 +308,6 @@ class Blocks {
         const stage = this.runtime.getTargetForStage();
         const editingTarget = this.runtime.getEditingTarget();
 
-        // UI event: clicked scripts toggle in the runtime.
-        if (e.element === 'stackclick') {
-            this.runtime.toggleScript(e.blockId, {stackClick: true});
-            return;
-        }
-
         // Block create/update/destroy
         switch (e.type) {
         case 'create': {
@@ -502,6 +496,10 @@ class Blocks {
 
                 this.emitProjectChanged();
             }
+            break;
+        case 'stackClick':
+            // UI event: clicked scripts toggle in the runtime.
+            this.runtime.toggleScript(e.blockId, {stackClick: true});
             break;
         }
     }


### PR DESCRIPTION
This PR updates the VM to listen for the stack click events introduced in https://github.com/gonfunko/scratch-blocks/pull/32. This makes the handling of these events consistent with other event types.