### PR TITLE
fix: use toolboxitemid instead of id as the identifier attribute for extension toolbox categories

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1429,7 +1429,7 @@ class Runtime extends EventEmitter {
 
             return {
                 id: categoryInfo.id,
-                xml: `<category name="${name}" id="${categoryInfo.id}" ${statusButtonXML} ${colorXML} ${menuIconXML}>${
+                xml: `<category name="${name}" toolboxitemid="${categoryInfo.id}" ${statusButtonXML} ${colorXML} ${menuIconXML}>${
                     paletteBlocks.map(block => block.xml).join('')}</category>`
             };
         });


### PR DESCRIPTION
This PR generates extension toolbox category definitions using the "new" `toolboxitemid` attribute instead of `id`.