### PR TITLE
fix: handle modern workspace comment events

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -430,8 +430,8 @@ class Blocks {
                     // comments, then the auto positioning should have taken place.
                     // Update the x and y position of these comments to match the
                     // one from the event.
-                    currTarget.comments[e.commentId].x = e.xy.x;
-                    currTarget.comments[e.commentId].y = e.xy.y;
+                    currTarget.comments[e.commentId].x = e.json.x;
+                    currTarget.comments[e.commentId].y = e.json.y;
                 }
             }
             this.emitProjectChanged();

--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -419,8 +419,8 @@ class Blocks {
         case 'comment_create':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
-                currTarget.createComment(e.commentId, e.blockId, e.text,
-                    e.xy.x, e.xy.y, e.width, e.height, e.minimized);
+                currTarget.createComment(e.commentId, null, '',
+                    e.json.x, e.json.y, e.json.width, e.json.height, false);
 
                 if (currTarget.comments[e.commentId].x === null &&
                     currTarget.comments[e.commentId].y === null) {
@@ -444,18 +444,7 @@ class Blocks {
                     return;
                 }
                 const comment = currTarget.comments[e.commentId];
-                const change = e.newContents_;
-                if (Object.prototype.hasOwnProperty.call(change, 'minimized')) {
-                    comment.minimized = change.minimized;
-                }
-                if (Object.prototype.hasOwnProperty.call(change, 'width') &&
-                    Object.prototype.hasOwnProperty.call(change, 'height')) {
-                    comment.width = change.width;
-                    comment.height = change.height;
-                }
-                if (Object.prototype.hasOwnProperty.call(change, 'text')) {
-                    comment.text = change.text;
-                }
+                comment.text = e.newContents_;
                 this.emitProjectChanged();
             }
             break;
@@ -471,6 +460,18 @@ class Blocks {
                 comment.x = newCoord.x;
                 comment.y = newCoord.y;
 
+                this.emitProjectChanged();
+            }
+            break;
+        case 'comment_collapse':
+            if (this.runtime.getEditingTarget()) {
+                const currTarget = this.runtime.getEditingTarget();
+                if (currTarget && !Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
+                    log.warn(`Cannot change comment with id ${e.commentId} because it does not exist.`);
+                    return;
+                }
+                const comment = currTarget.comments[e.commentId];
+                comment.minimized = e.newCollapsed;
                 this.emitProjectChanged();
             }
             break;

--- a/src/engine/comment.js
+++ b/src/engine/comment.js
@@ -31,7 +31,7 @@ class Comment {
     toXML () {
         return `<comment id="${this.id}" x="${this.x}" y="${
             this.y}" w="${this.width}" h="${this.height}" pinned="${
-            this.blockId !== null}" minimized="${this.minimized}">${xmlEscape(this.text)}</comment>`;
+            this.blockId !== null}" collapsed="${this.minimized}">${xmlEscape(this.text)}</comment>`;
     }
 
     // TODO choose min and defaults for width and height


### PR DESCRIPTION
This PR fixes (de)serialization and general interaction with modern workspace comments. Note that comment resizing is currently not handled, and is blocked by https://github.com/google/blockly/issues/8113 in Blockly core.