### PR TITLE
fix: handle new custom block comment events

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -416,10 +416,11 @@ class Blocks {
             this.emitProjectChanged();
             break;
         }
+        case 'block_comment_create':
         case 'comment_create':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
-                currTarget.createComment(e.commentId, null, '',
+                currTarget.createComment(e.commentId, e.blockId, '',
                     e.json.x, e.json.y, e.json.width, e.json.height, false);
 
                 if (currTarget.comments[e.commentId].x === null &&
@@ -436,6 +437,7 @@ class Blocks {
             }
             this.emitProjectChanged();
             break;
+        case 'block_comment_change':
         case 'comment_change':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
@@ -448,11 +450,12 @@ class Blocks {
                 this.emitProjectChanged();
             }
             break;
+        case 'block_comment_move':
         case 'comment_move':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
                 if (currTarget && !Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
-                    log.warn(`Cannot change comment with id ${e.commentId} because it does not exist.`);
+                    log.warn(`Cannot move comment with id ${e.commentId} because it does not exist.`);
                     return;
                 }
                 const comment = currTarget.comments[e.commentId];
@@ -463,11 +466,12 @@ class Blocks {
                 this.emitProjectChanged();
             }
             break;
+        case 'block_comment_collapse':
         case 'comment_collapse':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();
                 if (currTarget && !Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
-                    log.warn(`Cannot change comment with id ${e.commentId} because it does not exist.`);
+                    log.warn(`Cannot collapse comment with id ${e.commentId} because it does not exist.`);
                     return;
                 }
                 const comment = currTarget.comments[e.commentId];
@@ -475,6 +479,21 @@ class Blocks {
                 this.emitProjectChanged();
             }
             break;
+        case 'block_comment_resize':
+        case 'comment_resize':
+            if (this.runtime.getEditingTarget()) {
+                const currTarget = this.runtime.getEditingTarget();
+                if (currTarget && !Object.prototype.hasOwnProperty.call(currTarget.comments, e.commentId)) {
+                    log.warn(`Cannot resize comment with id ${e.commentId} because it does not exist.`);
+                    return;
+                }
+                const comment = currTarget.comments[e.commentId];
+                comment.width = e.newSize.width;
+                comment.height = e.newSize.height;
+                this.emitProjectChanged();
+            }
+            break;
+        case 'block_comment_delete':
         case 'comment_delete':
             if (this.runtime.getEditingTarget()) {
                 const currTarget = this.runtime.getEditingTarget();

--- a/src/engine/comment.js
+++ b/src/engine/comment.js
@@ -31,7 +31,7 @@ class Comment {
     toXML () {
         return `<comment id="${this.id}" x="${this.x}" y="${
             this.y}" w="${this.width}" h="${this.height}" pinned="${
-            this.blockId !== null}" collapsed="${this.minimized}">${xmlEscape(this.text)}</comment>`;
+            !this.minimized}" collapsed="${this.minimized}">${xmlEscape(this.text)}</comment>`;
     }
 
     // TODO choose min and defaults for width and height


### PR DESCRIPTION
This PR updates the VM to listen for the new custom block comment events fired in https://github.com/gonfunko/scratch-blocks/pull/83. It also modifies comment-to-blocks-xml conversion to encode the collapsed state of block comments in the otherwise-unused `pinned` attribute, since Scratch block comments are always visible (`pinned` normally corresponds to whether the bubble is visible or not), as the XML system doesn't have good extensibility to allow persisting this property in a better fashion.