### PR TITLE
fix: add the monitor block extension to extension monitor blocks

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1293,7 +1293,10 @@ class Runtime extends EventEmitter {
 
         if (blockInfo.blockType === BlockType.REPORTER) {
             if (!blockInfo.disableMonitor && context.inputList.length === 0) {
-                blockJSON.checkboxInFlyout = true;
+                if (!blockJSON.extensions) {
+                    blockJSON.extensions = [];
+                }
+                blockJSON.extensions.push("monitor_block");
             }
         } else if (blockInfo.blockType === BlockType.LOOP) {
             // Add icon to the bottom right of a loop block


### PR DESCRIPTION
This PR fixes a bug where extension blocks that designated themselves as monitor blocks did not appear as such in the flyout. It updates the VM to use the monitor block extension introduced in https://github.com/gonfunko/scratch-blocks/pull/167 rather than setting a boolean property that was ignored when deserializing block JSON.