### PR TITLE
fix: fix bug that could result in the VM's representation of shadow blocks getting into a bad state

### DIFF
--- a/src/engine/blocks.js
+++ b/src/engine/blocks.js
@@ -886,23 +886,32 @@ class Blocks {
                 typeof e.oldInput !== "undefined" &&
                 oldParent.inputs[e.oldInput].block === e.id
             ) {
-                // This block was connected to the old parent's input. We either
-                // want to restore the shadow block that previously occupied
-                // this input, or set it to null (which `.shadow` will be if
-                // there was no shadow previously)
-                oldParent.inputs[e.oldInput].block =
-                    oldParent.inputs[e.oldInput].shadow;
+                // This block was connected to an input. We either want to
+                // restore the shadow block that previously occupied
+                // this input, or null out the input's block.
+                const shadow = oldParent.inputs[e.oldInput].shadow;
+                if (shadow && e.id !== shadow) {
+                    oldParent.inputs[e.oldInput].block = shadow;
+                    this._blocks[shadow].parent = oldParent.id;
+                } else {
+                    oldParent.inputs[e.oldInput].block = null;
+                    if (e.id !== shadow) {
+                        this._blocks[e.id].parent = null;
+                    }
+                }
             } else if (oldParent.next === e.id) {
                 // This block was connected to the old parent's next connection.
                 oldParent.next = null;
+                this._blocks[e.id].parent = null;
             }
-            this._blocks[e.id].parent = null;
             didChange = true;
         }
 
         // Is this block a top-level block?
         if (typeof e.newParent === "undefined") {
-            this._addScript(e.id);
+            if (!this._blocks[e.id].shadow) {
+                this._addScript(e.id);
+            }
         } else {
             // Remove script, if one exists.
             this._deleteScript(e.id);


### PR DESCRIPTION
This PR builds on #8 to fix https://github.com/gonfunko/scratch-blocks/issues/204. While the prior fix improved things, the shadow block was (a) having its parent block set to null in the VM's internal representation and (b) being added as a top-level block in the internal representation, which violates the invariant that shadow blocks can never exist on their own. For reference, the exact sequence of events emitted is:

**Drag in a block to obscure a shadow block:**
1. Coordinate change move event for block being dragged, new/old input/parent are all undefined
2. Coordinate change for shadow block, new input/parent undefined, old input/parent set
3. New input/parent set for block being dragged

**Drag out a block to reveal a shadow block:**
1. Coordinate change for block being dragged, old input/parent set
2. Coordinate change for block being dragged, new/old parent/input undefined
(No events for shadow block)

Now, when the shadow block is restored, it also has its parent set correctly, and we avoid nulling it out in the first place. There is also a check to prevent creating shadow blocks as top-level blocks.